### PR TITLE
Don't Emit Changed When Updating Apt Cache

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -20,3 +20,4 @@
 - name: apt-get update
   apt:
     update_cache: yes
+  changed_when: False


### PR DESCRIPTION
Changed status might be emitted when updating apt cache, depending on
Ansible version.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>